### PR TITLE
Add copy rca script

### DIFF
--- a/SH/CloneRCAonly.sh
+++ b/SH/CloneRCAonly.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# CloneRepos.sh - Clone required repositories ready for build
+# CloneRCAonly.sh - Clone RCA repository ready to copy executables
 ########################################################
 
 main() {

--- a/SH/CloneRCAonly.sh
+++ b/SH/CloneRCAonly.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# CloneRepos.sh - Clone required repositories ready for build
+########################################################
+
+main() {
+
+echo "$(date) ${BASH_SOURCE##*/} Start process of cloning RCA";
+save_pwd=$(pwd);
+# extract repository name
+RCA_REPO=$(basename $GERS_REMOTE_RUN .git);
+if [ "$msgLevel"  == "verbose" ]; then
+  echo "Repository names";
+  echo $RCA_REPO ;
+fi 
+# Change into local directory where you want to clone to
+cd $GERS_GIT_REPO_DIR ;
+exitIfError;
+# Clone RCA repo, or clean the Test Framework output dir
+if [ "$GERS_CLONE_RCA" == "Y" ]; then
+  rm -rf $RCA_REPO;
+  exitIfError;
+  git clone --progress $GERS_REMOTE_RUN ;
+  exitIfError;
+  echo "$(date) ${BASH_SOURCE##*/} RCA Repository cloned";
+else
+  echo "$(date) ${BASH_SOURCE##*/} RCA Repository not cloned: GERS_CLONE_RCA=$GERS_CLONE_RCA";
+fi
+cd $RCA_REPO;
+git checkout $GERS_BRANCH_RCA ;
+exitIfError;
+echo "$(date) ${BASH_SOURCE##*/} RCA branch checked out";
+cd $save_pwd ;
+
+}
+
+exitIfError() {
+
+if [ $? != 0 ]
+then
+    echo "$(date) ${BASH_SOURCE##*/} *** Process terminated: see error message above";
+    exit 1;
+fi 
+
+}
+
+main "$@"

--- a/SH/CopyRCAppsOnly.sh
+++ b/SH/CopyRCAppsOnly.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# CopyRCAppsOnly.sh Copy RCA to RCA jar
+#######################################
+main() {
+
+RCA_REPO=$(basename $GERS_REMOTE_RUN .git);
+if [ "$msgLevel"  == "verbose" ]; then
+  echo $RCA_REPO ;
+fi 
+save_pwd=$(pwd) ;
+MINOR_REL="PM"$GERS_BUILD_VERSION$GERS_BUILD_MAJOR$GERS_BUILD_MINOR;
+# Are we building on zOS ?
+if [ "$GERS_BUILD_RCA" == "WIN" ]; then 
+# already built on Windows and uploaded to zOS
+  echo "$(date) ${BASH_SOURCE##*/} Copy and link Windows built RCA";
+  cd $GERS_GIT_REPO_DIR/$RCA_REPO;
+  exitIfError ;
+
+  export rev=`grep "<revision>" pom.xml | awk -F'<revision>|</revision>' '{print $2}'`;
+  echo "$(date) ${BASH_SOURCE##*/} RCA release number $rev";
+
+  cd RCApps/target ;
+  exitIfError ;
+  chtag -b *.jar ;
+  chmod 775 *.jar ;
+  exitIfError ;  
+  cp rcapps-$rev-jar-with-dependencies.jar $GERS_RCA_JAR_DIR/rcapps-$rev.jar;
+  exitIfError ;  
+  cd $GERS_RCA_JAR_DIR;
+
+  touch rcapps-latest.jar;
+  rm rcapps-latest.jar;
+  ln -s rcapps-$rev.jar rcapps-latest.jar;
+  exitIfError ;  
+
+  touch rcapps-$MINOR_REL.jar;
+  rm rcapps-$MINOR_REL.jar;
+  ln -s rcapps-$rev.jar rcapps-$MINOR_REL.jar;
+  exitIfError ;  
+
+  cd $GERS_GIT_REPO_DIR/$RCA_REPO;
+  cd PETestFramework/target;
+  exitIfError ;
+  chtag -b  *.jar;
+  chmod 775 *.jar;
+  exitIfError ;  
+  cd bin;
+  chmod 775 gerstf;
+  exitIfError ;  
+
+  if [ "$GERS_RUN_TESTS" == "Y" ]; then 
+    echo "$(date) ${BASH_SOURCE##*/} Run regression tests";
+    cd $GERS_GIT_REPO_DIR/$RCA_REPO/PETestFramework/;
+    exitIfError ;
+    ./target/bin/gerstf ;
+    exitIfError ;
+    cd out;
+    chtag  -R -c 819 *;
+    chtag  -R -t *;
+    cat fmoverview.txt ;  
+  fi 
+else
+
+  echo "$(date) ${BASH_SOURCE##*/} GERS_BUILD_RCA not set to WIN";
+
+fi 
+
+cd $save_pwd ;
+
+}
+
+exitIfError() {
+
+if [ $? != 0 ]
+then
+    echo "*** Process terminated: see error message above";
+    exit 1;
+fi 
+
+}
+
+main "$@"

--- a/SH/CopyRCAppsOnly.sh
+++ b/SH/CopyRCAppsOnly.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# CopyRCAppsOnly.sh Copy RCA to RCA jar
+# CopyRCAppsOnly.sh Copy RCA to RCA jar directory
 #######################################
 main() {
 
@@ -49,6 +49,8 @@ if [ "$GERS_BUILD_RCA" == "WIN" ]; then
   exitIfError ;  
 
   if [ "$GERS_RUN_TESTS" == "Y" ]; then 
+  # regression tests will be run against 'GERS_ENV_HLQ'.GVBLOAD data set (often set as LATEST)
+  # and the newly copied and linked 'rcapps-latest.jar'
     echo "$(date) ${BASH_SOURCE##*/} Run regression tests";
     cd $GERS_GIT_REPO_DIR/$RCA_REPO/PETestFramework/;
     exitIfError ;

--- a/copyRCA.sh
+++ b/copyRCA.sh
@@ -8,8 +8,7 @@ if [ "$opt1"  == "-v" ]; then
     export msgLevel=verbose;
 fi
 # Re-read the gers profile in case anything changed
-# source ~/.gers.profile ;
-source .gers.profile.gill ; 
+source ~/.gers.profile ;
 exitIfError;
 # Get DevOps repo name from repo address
 DEV_REPO=$(basename $GERS_REMOTE_DEV .git);
@@ -42,7 +41,7 @@ sendTSOMsg 'Cloning the RCA repository...                       ';
 # Copy built RCA to jar directory
 sendTSOMsg 'Copying the RCA to the RCA jar directory';             
 . ./CopyRCAppsOnly.sh  2> >(tee -a $err_log) > >(tee -a $out_log);
-echo "$(date) ${BASH_SOURCE##*/} Build process completed for PM$GERS_PE_REL_NBR_FORMATTED.B$BUILD_NBR" | tee -a $out_log ;
+echo "$(date) ${BASH_SOURCE##*/} RCA Copy process completed" | tee -a $out_log ;
 }
 
 sendTSOMsg() {
@@ -66,7 +65,6 @@ if [  "$(pwd)" != "${GERS_GIT_REPO_DIR%/}/$DEV_REPO" ]; then
  fi 
 
 }
-
 
 exitIfError() {
 

--- a/copyRCA.sh
+++ b/copyRCA.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# build.sh - Build GenevaERS 
+########################################################
+main() {
+opt1="$1";
+if [ "$opt1"  == "-v" ]; then
+    echo "Verbose message level";
+    export msgLevel=verbose;
+fi
+# Re-read the gers profile in case anything changed
+# source ~/.gers.profile ;
+source .gers.profile.gill ; 
+exitIfError;
+# Get DevOps repo name from repo address
+DEV_REPO=$(basename $GERS_REMOTE_DEV .git);
+# Check if run from TSO - used by sendTSOMsg
+if [ -z "$USER" ] ; then
+    userTSO='Y'; 
+else 
+    userTSO='N'; 
+    checkPWD;
+    exitIfError;
+fi 
+# Change to shell script directory SH
+cd $GERS_GIT_REPO_DIR/$DEV_REPO/SH ;
+exitIfError;
+sendTSOMsg 'Starting the RCA copy process...                    ';
+# Create the log files
+sendTSOMsg 'Creating the log files...                           ';
+. ./CreateLogs.sh ;
+# set env vars for build messages
+# Release Number. (Example: 501001) -->
+export GERS_PE_REL_NBR=$GERS_BUILD_VERSION$GERS_BUILD_MAJOR$GERS_BUILD_MINOR;
+# Release number formatted with dots. (Example: 5.01.001) -->
+export GERS_PE_REL_NBR_FORMATTED=$GERS_BUILD_VERSION.$GERS_BUILD_MAJOR.$GERS_BUILD_MINOR;
+# Write environment vars to log
+env | grep 'GERS_' | sort | tee -a $out_log;
+# Create build number and set HLQ
+# Clone the RCA repository, and checkout branches.
+sendTSOMsg 'Cloning the RCA repository...                       ';             
+. ./CloneRCAonly.sh  2> >(tee -a $err_log) > >(tee -a $out_log);
+# Copy built RCA to jar directory
+sendTSOMsg 'Copying the RCA to the RCA jar directory';             
+. ./CopyRCAppsOnly.sh  2> >(tee -a $err_log) > >(tee -a $out_log);
+echo "$(date) ${BASH_SOURCE##*/} Build process completed for PM$GERS_PE_REL_NBR_FORMATTED.B$BUILD_NBR" | tee -a $out_log ;
+}
+
+sendTSOMsg() {
+
+if [ "$userTSO" == "Y" ]; then 
+    tsocmd "send '$(date '+%H.%M.%S') $1' user("$LOGNAME")" ;
+    if [ $? != 0 ] ; then
+        userTSO='N'; 
+    fi  
+fi   
+
+}
+
+checkPWD() {
+
+if [  "$(pwd)" != "${GERS_GIT_REPO_DIR%/}/$DEV_REPO" ]; then
+  echo "$(date) ${BASH_SOURCE##*/} Environment Variable GERS_GIT_REPO_DIR = '$GERS_GIT_REPO_DIR'" ;
+  echo "$(date) ${BASH_SOURCE##*/} DevOps directory name ='$DEV_REPO'" ;
+  echo "$(date) ${BASH_SOURCE##*/} They must match with the current directory '$(pwd)'" ;
+  return 1;
+ fi 
+
+}
+
+
+exitIfError() {
+
+if [ $? != 0 ]
+then
+    echo "*** Process terminated: see error message above";
+    exit 1;
+fi 
+
+}
+
+main "$@"

--- a/copyRCA.sh
+++ b/copyRCA.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# build.sh - Build GenevaERS 
+# copyRCA.sh - Copy RCA executables (previously built on Windows) 
 ########################################################
 main() {
 opt1="$1";


### PR DESCRIPTION
I've added a new script to be used in conjunction with hot fix instructions.
This assumes RCApps has been build on Windows, and then copied back to a repository.
copyRCA.sh will clone the repository (named in the .gers.profile by GERS_REMOTE_RUN) and copy to the directory named in GERS_RCA_JAR_DIR .
It then issues all the appropriate chtag and chmod commands.